### PR TITLE
feat: add support for variable profiles and shot history

### DIFF
--- a/meticulous/api_types.py
+++ b/meticulous/api_types.py
@@ -183,3 +183,8 @@ class ProfileEvent(BaseModel):
 class MachineInfo(BaseModel):
     software_info: Dict[str, Union[str, int, float]]
     esp_info: Dict[str, Union[str, int, float]]
+
+
+class HistoryFile(BaseModel):
+    name: str
+    url: str

--- a/meticulous/profile.py
+++ b/meticulous/profile.py
@@ -22,21 +22,21 @@ class Variable(BaseModel):
 
 
 class Dynamics(BaseModel):
-    points: List[List[float]]
+    points: List[List[Union[float, str]]]
     over: str
     interpolation: str
 
 
 class ExitTrigger(BaseModel):
     type: str
-    value: float
+    value: Union[float, str]
     relative: Optional[bool] = None
     comparison: Optional[str] = None
 
 
 class Limit(BaseModel):
     type: str
-    value: float
+    value: Union[float, str]
 
 
 class Stage(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
     "requests>=2.32.3",
     "pydantic>=2.7.3",
     "python-socketio>=5.11.2",
-    "websocket-client>=1.8.0"
+    "websocket-client>=1.8.0",
+    "zstandard>=0.22.0"
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ flake8-black>=0.3.6
 python-socketio>=5.11.2
 pytest>=8.2.2
 websocket-client>=1.8.0
+zstandard>=0.22.0


### PR DESCRIPTION
Enables fetching shot history logs (including .zst decompression) and supports string values (including '$') in profile fields for variables.