### PR TITLE
Make HistoryDataPoint.sensors optional, add Display metadata

### DIFF
--- a/meticulous/api_types.py
+++ b/meticulous/api_types.py
@@ -378,7 +378,7 @@ class HistoryDataPoint(BaseModel):
     shot: HistoryShotData
     time: int
     status: str
-    sensors: HistorySensorData
+    sensors: Optional[HistorySensorData] = None
 
 
 class ShotRating(str, Enum):

--- a/meticulous/profile.py
+++ b/meticulous/profile.py
@@ -12,6 +12,8 @@ class Display(BaseModel):
     image: Optional[Union[AnyUrl, str]] = None
     # RGB Value in the #AABBCC format
     accentColor: Optional[str] = Field(None, pattern=r"^#[0-9A-Fa-f]{6}$")
+    shortDescription: Optional[str] = None
+    description: Optional[str] = None
 
 
 class Variable(BaseModel):


### PR DESCRIPTION
## Summary
- **`HistoryDataPoint.sensors`**: Made optional. Machine firmware omits the `sensors` field on the final retraction data point in shot history, causing `ValidationError` when calling `get_last_shot()`.
- **`Display` model**: Added `shortDescription` and `description` optional fields so they survive model serialization round-trips.

## Context
Both issues affect downstream consumers (HA add-on, MCP server):
- Missing `sensors` prevents the HA add-on from updating last shot info after every extraction
- Missing Display fields force the MCP server to bypass pyMeticulous serialization to preserve profile descriptions

## Evidence
Checked 5 consecutive shots across different profiles — the last data point always omits `sensors`:
```
Prism: 783 pts — MISSING at [782]
A-Flow v2: 865 pts — MISSING at [864]
A-Flow v2: 727 pts — MISSING at [726]
Terraced: 877 pts — MISSING at [876]
A-Flow v2: 907 pts — MISSING at [906]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)